### PR TITLE
Fix potential typo in IOverrideSchedule.

### DIFF
--- a/client/src/reducers/mealSchedule.ts
+++ b/client/src/reducers/mealSchedule.ts
@@ -18,7 +18,7 @@ const INITIAL_STATE : ISubscriptionSchedule = {
     SATURDAY:null,
     SUNDAY:null
   },
-  overrideSchedule :  []
+  overrideSchedules :  []
 };
 
 export default function(state = INITIAL_STATE, action: any) {
@@ -28,10 +28,10 @@ export default function(state = INITIAL_STATE, action: any) {
     case GET_SUBSCRIBER_OVERRIDESCHEDULE:
       return { ...state, overrideSchedules: action.payload };
     case ADD_SUBSCRIBER_OVERRIDESCHEDULE:
-      let overrideSchedules = state.overrideSchedule as Array<IOverrideSchedule>;
+      let overrideSchedules = state.overrideSchedules as Array<IOverrideSchedule>;
       return { ...state, overrideSchedules: [...overrideSchedules, action.payload] };
     case DELETE_SUBSCRIBER_OVERRIDESCHEDULE:
-      let delOverrideSchedules = state.overrideSchedule as Array<IOverrideSchedule>;
+      let delOverrideSchedules = state.overrideSchedules as Array<IOverrideSchedule>;
       delOverrideSchedules = delOverrideSchedules.filter((schedule:IOverrideSchedule) => schedule.overrideStartDate != action.payload )
       return { ...state, overrideSchedules: [ ...delOverrideSchedules] };
     case API_USER_ERROR:

--- a/client/src/reducers/mealSchedule.ts
+++ b/client/src/reducers/mealSchedule.ts
@@ -18,7 +18,7 @@ const INITIAL_STATE : ISubscriptionSchedule = {
     SATURDAY:null,
     SUNDAY:null
   },
-  overrideSchedules :  []
+  overrideSchedule :  []
 };
 
 export default function(state = INITIAL_STATE, action: any) {
@@ -28,10 +28,10 @@ export default function(state = INITIAL_STATE, action: any) {
     case GET_SUBSCRIBER_OVERRIDESCHEDULE:
       return { ...state, overrideSchedules: action.payload };
     case ADD_SUBSCRIBER_OVERRIDESCHEDULE:
-      let overrideSchedules = state.overrideSchedules as Array<IOverrideSchedule>;
+      let overrideSchedules = state.overrideSchedule as Array<IOverrideSchedule>;
       return { ...state, overrideSchedules: [...overrideSchedules, action.payload] };
     case DELETE_SUBSCRIBER_OVERRIDESCHEDULE:
-      let delOverrideSchedules = state.overrideSchedules as Array<IOverrideSchedule>;
+      let delOverrideSchedules = state.overrideSchedule as Array<IOverrideSchedule>;
       delOverrideSchedules = delOverrideSchedules.filter((schedule:IOverrideSchedule) => schedule.overrideStartDate != action.payload )
       return { ...state, overrideSchedules: [ ...delOverrideSchedules] };
     case API_USER_ERROR:
@@ -40,4 +40,3 @@ export default function(state = INITIAL_STATE, action: any) {
       return state;
   }
 }
- 

--- a/client/src/reducers/mealscheduleAction.ts
+++ b/client/src/reducers/mealscheduleAction.ts
@@ -18,8 +18,8 @@ export const getSubscriptionSchedule = (subscriberId: string, workFlowProcessor:
     if(response && response.data) {
       const subscriptionSchedule: ISubscriptionSchedule = response.data;
       dispatch({ type: GET_SUBSCRIBER_SCHEDULE , payload: subscriptionSchedule.optedSchedule });
-      if(subscriptionSchedule && subscriptionSchedule.overrideSchedule && subscriptionSchedule.overrideSchedule[0]) {
-        dispatch({ type: GET_SUBSCRIBER_OVERRIDESCHEDULE , payload: subscriptionSchedule.overrideSchedule });
+      if(subscriptionSchedule && subscriptionSchedule.overrideSchedules && subscriptionSchedule.overrideSchedules[0]) {
+        dispatch({ type: GET_SUBSCRIBER_OVERRIDESCHEDULE , payload: subscriptionSchedule.overrideSchedules });
       }  
     }
     workFlowProcessor && workFlowProcessor(response.data.workFlowResponse && response.data.workFlowResponse.goToRoute);

--- a/client/src/reducers/mealscheduleAction.ts
+++ b/client/src/reducers/mealscheduleAction.ts
@@ -18,9 +18,7 @@ export const getSubscriptionSchedule = (subscriberId: string, workFlowProcessor:
     if(response && response.data) {
       const subscriptionSchedule: ISubscriptionSchedule = response.data;
       dispatch({ type: GET_SUBSCRIBER_SCHEDULE , payload: subscriptionSchedule.optedSchedule });
-      //@ts-ignore
       if(subscriptionSchedule && subscriptionSchedule.overrideSchedule && subscriptionSchedule.overrideSchedule[0]) {
-        //@ts-ignore
         dispatch({ type: GET_SUBSCRIBER_OVERRIDESCHEDULE , payload: subscriptionSchedule.overrideSchedule });
       }  
     }

--- a/client/src/type/Type.ts
+++ b/client/src/type/Type.ts
@@ -20,7 +20,7 @@ export interface ISubscriptionSchedule {
     SATURDAY?: string | null;
     SUNDAY?: string | null;
   }
-  overrideSchedules ?:  Array<IOverrideSchedule> | null;
+  overrideSchedule ?:  Array<IOverrideSchedule> | null;
   
 }
 

--- a/client/src/type/Type.ts
+++ b/client/src/type/Type.ts
@@ -20,7 +20,7 @@ export interface ISubscriptionSchedule {
     SATURDAY?: string | null;
     SUNDAY?: string | null;
   }
-  overrideSchedule ?:  Array<IOverrideSchedule> | null;
+  overrideSchedules ?:  Array<IOverrideSchedule> | null;
   
 }
 


### PR DESCRIPTION

There are two files referring to a property in IOverrideSchedule but one of them has a typo (which was not caught because of tslint-ignore). I verified the eoutput from API and changed to the correct property returned by the API.