### PR TITLE
Build with NodeJS 12

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pool:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '10.x'
+    versionSpec: '12.x'
   displayName: 'Install Node.js'
 
 - script: |


### PR DESCRIPTION
Let's use the latest LTS version of Node as development is also on that version (which correspondingly builds the appropriate packages)